### PR TITLE
Fix explorer context menu item ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -311,7 +311,7 @@
       "explorer/context": [
         {
           "command": "secondary-explorer.addToSecondaryExplorer",
-          "group": "navigation@1"
+          "group": "navigation@99"
         }
       ],
       "editor/title/context": [


### PR DESCRIPTION
The extension currently contributes its Explorer context menu item to `navigation@1`, which places it at the very top of the menu.

This change moves it to a lower priority (`navigation@99`) so it appears after core file/folder operations.